### PR TITLE
Report artifact removal

### DIFF
--- a/cache/src/dist/config/development.yml
+++ b/cache/src/dist/config/development.yml
@@ -32,5 +32,8 @@ authenticationConfig:
   tokens:
 
 statsd:
-  enabled: false
-
+  enabled: true
+  host: localhost
+  port: 8125
+  prefix: buck_cache.test
+  sampleRate: 1.0

--- a/cache/src/main/java/com/uber/buckcache/datastore/impl/ignite/IgniteConstants.java
+++ b/cache/src/main/java/com/uber/buckcache/datastore/impl/ignite/IgniteConstants.java
@@ -18,6 +18,7 @@ public class IgniteConstants {
       put(EventType.EVT_CACHE_OBJECT_EXPIRED, "EXPIRED");
       put(EventType.EVT_CACHE_OBJECT_REMOVED, "REMOVED");
       put(EventType.EVT_CACHE_ENTRY_EVICTED, "EVICTED");
+      put(EventType.EVT_CACHE_ENTRY_DESTROYED, "DESTROYED");
     }
   };
 }

--- a/cache/src/main/java/com/uber/buckcache/datastore/impl/ignite/IgniteInstance.java
+++ b/cache/src/main/java/com/uber/buckcache/datastore/impl/ignite/IgniteInstance.java
@@ -63,8 +63,15 @@ public class IgniteInstance {
     buckDataCache = ignite.cluster().ignite().getOrCreateCache(METADATA_CACHE_NAME);
     atomicSequence = ignite.cluster().ignite().atomicSequence(UNDERLYING_KEY_SEQUENCE_NAME, 0, true);
 
+    int[] localListenEvents = {
+      EventType.EVT_CACHE_OBJECT_EXPIRED,
+      EventType.EVT_CACHE_OBJECT_REMOVED,
+      EventType.EVT_CACHE_ENTRY_EVICTED,
+      EventType.EVT_CACHE_ENTRY_DESTROYED,
+    };
+    ignite.events().enableLocal(localListenEvents);
     ignite.events().localListen(new LocalCacheEventListener(buckDataCache, reverseCacheKeys, cacheKeys),
-        EventType.EVT_CACHE_OBJECT_EXPIRED, EventType.EVT_CACHE_OBJECT_REMOVED);
+      localListenEvents);
   }
 
   public void start() {

--- a/cache/src/main/java/com/uber/buckcache/utils/MetricsRegistry.java
+++ b/cache/src/main/java/com/uber/buckcache/utils/MetricsRegistry.java
@@ -34,7 +34,5 @@ public class MetricsRegistry {
   public static final String SUMMARY_ERROR_COUNT = "summary_error_count";
   public static final String GET_ERROR_COUNT = "get_artifact_resource_error_count";
   public static final String PUT_ERROR_COUNT = "put_artifact_resource_error_count";
-
-  public static final String ARTIFACT_EVICTION_COUNT = "artifact_eviction_count";
   
 }

--- a/run_buck_cache_client.sh
+++ b/run_buck_cache_client.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -ex
+
 ./gradlew distJar
 
 $JAVA_HOME/bin/java -Xmx16G  -XX:+UseG1GC -XX:MaxGCPauseMillis=100 -XX:MaxDirectMemorySize=6g -Dlog.home=/var/log/buck-cache-client/logs -jar cache/build/libs/cache-1.0.4-standalone.jar server cache/src/dist/config/$1.yml


### PR DESCRIPTION
**This diff adds tracking for when artifacts are removed from the cache.** 
Reasons they can get removed:
- TTL expired for the item
- Evicted due to resource constraints
- Removed explicitly via HTTP API
- cache destroyed for any reason

**How was it tested:**
Deployed the change on a machine
Observed that logs are coming through
