### PR TITLE
Monitoring instrumentation improvements

### DIFF
--- a/cache/build.gradle
+++ b/cache/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     compile deps.external.jackson
     compile deps.external.uuidGen
     compile deps.external.httpCore
-    compile deps.external.statsdClient
+    compile deps.external.dogstatsdClient
     compile deps.external.dns
     testCompile 'org.mockito:mockito-all:1.9.5'
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -7,6 +7,7 @@ def versions = [
         jacksonVersion: "2.8.2",
         uuidGenVersion: "3.1.3",
         statsdClientVersion: "3.0.1",
+        dogstatsdClientVersion: "2.7",
         dnsVersion: "3.1.4",
 ]
 
@@ -25,6 +26,7 @@ def external = [
         jackson           : "com.fasterxml.jackson.core:jackson-databind:${versions.jacksonVersion}",
         uuidGen           : "com.fasterxml.uuid:java-uuid-generator:${versions.uuidGenVersion}",
         statsdClient      : "com.timgroup:java-statsd-client:${versions.statsdClientVersion}",
+        dogstatsdClient   : "com.datadoghq:java-dogstatsd-client:${versions.dogstatsdClientVersion}",
         dns               : "com.spotify:dns:${versions.dnsVersion}",
 ]
 


### PR DESCRIPTION
**Summary**
- Support datadog-custom-tags for reporting metrics by switching to `java-dogstatsd-client` from `java-statsd-client`
- Support cache-tags in PUT requests API
- Annotate reported metrics with cache-tags for GET and PUT requests

**How was it tested:**
Test1
1. Run cache-server locally
2. trigger a buck-build pointing to local cache
3. tail `statsd` logs
4. verify that appropriate custom tags are coming through

Test2
1. deployed the change on a machine in production
2. Verify that appropriate metrics show up in monitoring dashboards