### PR TITLE
[buck-cache] make underlyingId more unique using rule-keys

### DIFF
--- a/cache/src/main/java/com/uber/buckcache/datastore/impl/ignite/IgniteConstants.java
+++ b/cache/src/main/java/com/uber/buckcache/datastore/impl/ignite/IgniteConstants.java
@@ -7,11 +7,11 @@ import org.apache.ignite.events.EventType;
 
 public class IgniteConstants {
 
-  public static final String KEYS_CACHE_NAME = "keys";
-  public static final String KEYS_REVERSE_CACHE_NAME = "keys-reverse";
-  public static final String METADATA_CACHE_NAME = "metadata";
-  public static final String ARTIFACT_CACHE_NAME = "artifacts";
-  public static final String UNDERLYING_KEY_SEQUENCE_NAME = "underlyingArtifactKeys";
+  public static final String KEYS_CACHE_NAME = "keys-v1";
+  public static final String KEYS_REVERSE_CACHE_NAME = "keys-reverse-v1";
+  public static final String METADATA_CACHE_NAME = "metadata-v1";
+  public static final String ARTIFACT_CACHE_NAME = "artifacts-v1";
+  public static final String UNDERLYING_KEY_SEQUENCE_NAME = "underlyingArtifactKeys-v1";
 
   public static final Map<Integer, String> EVENT_TYPE_TO_NAME_MAP = new HashMap<Integer, String>() {
     {

--- a/cache/src/main/java/com/uber/buckcache/datastore/impl/ignite/IgniteInstance.java
+++ b/cache/src/main/java/com/uber/buckcache/datastore/impl/ignite/IgniteInstance.java
@@ -39,9 +39,9 @@ public class IgniteInstance {
   private final Ignite ignite;
 
   private final IgniteAtomicSequence atomicSequence;
-  private final IgniteCache<String, Long> cacheKeys;
-  private final IgniteCache<Long, String[]> reverseCacheKeys;
-  private final IgniteCache<Long, byte[]> buckDataCache;
+  private final IgniteCache<String, String> cacheKeys;
+  private final IgniteCache<String, String[]> reverseCacheKeys;
+  private final IgniteCache<String, byte[]> buckDataCache;
   private final Timer timer = new Timer("ignite_metrics_reporter");
 
   public IgniteInstance(CacheInstanceMode mode, IgniteConfig config) {
@@ -89,19 +89,19 @@ public class IgniteInstance {
     Ignition.stop(ignite.name(), false);
   }
 
-  public IgniteCache<String, Long> getCacheKeys() {
+  public IgniteCache<String, String> getCacheKeys() {
     return cacheKeys;
   }
 
-  public IgniteCache<Long, String[]> getReverseCacheKeys() {
+  public IgniteCache<String, String[]> getReverseCacheKeys() {
     return reverseCacheKeys;
   }
 
-  public IgniteCache<Long, byte[]> getBuckDataCache() {
+  public IgniteCache<String, byte[]> getBuckDataCache() {
     return buckDataCache;
   }
 
-  public IgniteCache<String, Long> getCacheKeys(Optional<ExpiryPolicy> policy) {
+  public IgniteCache<String, String> getCacheKeys(Optional<ExpiryPolicy> policy) {
     if (policy.isPresent()) {
       return cacheKeys.withExpiryPolicy(policy.get());
     } else {
@@ -109,7 +109,7 @@ public class IgniteInstance {
     }
   }
 
-  public IgniteCache<Long, String[]> getReverseCacheKeys(Optional<ExpiryPolicy> policy) {
+  public IgniteCache<String, String[]> getReverseCacheKeys(Optional<ExpiryPolicy> policy) {
     if (policy.isPresent()) {
       return reverseCacheKeys.withExpiryPolicy(policy.get());
     } else {
@@ -117,7 +117,7 @@ public class IgniteInstance {
     }
   }
 
-  public IgniteCache<Long, byte[]> getBuckDataCache(Optional<ExpiryPolicy> policy) {
+  public IgniteCache<String, byte[]> getBuckDataCache(Optional<ExpiryPolicy> policy) {
     if (policy.isPresent()) {
       return buckDataCache.withExpiryPolicy(policy.get());
     } else {

--- a/cache/src/main/java/com/uber/buckcache/datastore/impl/ignite/LocalCacheEventListener.java
+++ b/cache/src/main/java/com/uber/buckcache/datastore/impl/ignite/LocalCacheEventListener.java
@@ -13,12 +13,12 @@ import static com.uber.buckcache.datastore.impl.ignite.IgniteConstants.EVENT_TYP
 public class LocalCacheEventListener implements IgnitePredicate<CacheEvent> {
   private static Logger logger = LoggerFactory.getLogger(LocalCacheEventListener.class);
 
-  private final IgniteCache<Long, byte[]> metadataCache;
-  private final IgniteCache<Long, String[]> reverseCacheKeys;
-  private final IgniteCache<String, Long> cacheKeys;
+  private final IgniteCache<String, byte[]> metadataCache;
+  private final IgniteCache<String, String[]> reverseCacheKeys;
+  private final IgniteCache<String, String> cacheKeys;
 
-  public LocalCacheEventListener(IgniteCache<Long, byte[]> metadataCache, IgniteCache<Long, String[]> reverseCacheKeys,
-      IgniteCache<String, Long> cacheKeys) {
+  public LocalCacheEventListener(IgniteCache<String, byte[]> metadataCache, IgniteCache<String, String[]> reverseCacheKeys,
+      IgniteCache<String, String> cacheKeys) {
     this.metadataCache = metadataCache;
     this.reverseCacheKeys = reverseCacheKeys;
     this.cacheKeys = cacheKeys;
@@ -37,7 +37,7 @@ public class LocalCacheEventListener implements IgnitePredicate<CacheEvent> {
 
       final String eventName =
           EVENT_TYPE_TO_NAME_MAP.containsKey(evt.type()) ? EVENT_TYPE_TO_NAME_MAP.get(evt.type()) : "UNKNOWN";
-      Long underlyingKey = evt.key();
+      String underlyingKey = evt.key();
       String[] keys = reverseCacheKeys.getAndRemove(underlyingKey);
 
       logger.info(String.format("Artifact cache event {} with key {}.", eventName, underlyingKey), keys, evt);

--- a/cache/src/main/java/com/uber/buckcache/utils/MetricsRegistry.java
+++ b/cache/src/main/java/com/uber/buckcache/utils/MetricsRegistry.java
@@ -23,6 +23,7 @@ public class MetricsRegistry {
   public static final String IGNITE_CACHE_PUT_CALL_COUNT = "ignite_cache_put_count";
   public static final String IGNITE_CACHE_PUT_CALL_TIME = "ignite_cache_put_time";
   public static final String IGNITE_CACHE_PUT_ARTIFACT_COLLISION_COUNT = "ignite_cache_put_artifact_collision_count";
+  public static final String IGNITE_CACHE_PUT_NO_RULEKEYS_COUNT = "ignite_cache_put_no_rulekeys_count";
 
   
   public static final String CPU_COUNT = "buck_cache_server_cpu_usage";


### PR DESCRIPTION
Context:
Logging suggests that auto-increment-ids collide sometimes. Let's use first Rulekey to make underlyingID more unique

Tested by running cache-server locally and doing a buck-build