### PR TITLE
Adds endpoint to fetch dummy data to determine network speed

### DIFF
--- a/cache/src/main/java/com/uber/buckcache/resources/buckcache/BuckCacheResource.java
+++ b/cache/src/main/java/com/uber/buckcache/resources/buckcache/BuckCacheResource.java
@@ -80,7 +80,7 @@ public class BuckCacheResource {
 
   /**
    * Used for client side to measure download speed.
-   * @param size - in kilobytes
+   * @param size - in kilobytes, max of 1024 kilobytes
    * @return byte[] - with size in kilobytes
    * @throws Exception
    */
@@ -88,6 +88,9 @@ public class BuckCacheResource {
   @Path("dummy/{size}")
   @Produces(MediaType.APPLICATION_OCTET_STREAM)
   public Response getDummyArtifact(@PathParam("size") int size) throws Exception {
+    if (size > 1024) {
+      return Response.status(Response.Status.NOT_ACCEPTABLE).entity("Max of 1024 Kilobytes").build();
+    }
     Random rand = new Random();
     rand.setSeed(System.currentTimeMillis());
     try {

--- a/cache/src/main/java/com/uber/buckcache/resources/buckcache/BuckCacheResource.java
+++ b/cache/src/main/java/com/uber/buckcache/resources/buckcache/BuckCacheResource.java
@@ -9,6 +9,7 @@ import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.security.PermitAll;
 import javax.ws.rs.Consumes;
@@ -74,6 +75,29 @@ public class BuckCacheResource {
       e.printStackTrace();
       StatsDClient.get().count(SUMMARY_ERROR_COUNT, 1L);
       return "I am broken";
+    }
+  }
+
+  /**
+   * Used for client side to measure download speed.
+   * @param size
+   * @return
+   * @throws Exception
+   */
+  @GET
+  @Path("dummy")
+  @Produces(MediaType.APPLICATION_OCTET_STREAM)
+  public String getDummyArtifact() throws Exception {
+    Random rand = new Random();
+    rand.setSeed(System.currentTimeMillis());
+    try {
+      // 100Kb
+      byte[] bytes = new byte[100000];
+      rand.nextBytes(bytes);
+      return new String(bytes);
+    } catch (Exception e) {
+      e.printStackTrace();
+      return e.getMessage();
     }
   }
 

--- a/cache/src/main/java/com/uber/buckcache/resources/buckcache/BuckCacheResource.java
+++ b/cache/src/main/java/com/uber/buckcache/resources/buckcache/BuckCacheResource.java
@@ -80,24 +80,23 @@ public class BuckCacheResource {
 
   /**
    * Used for client side to measure download speed.
-   * @param size
-   * @return
+   * @param size - in kilobytes
+   * @return byte[] - with size in kilobytes
    * @throws Exception
    */
   @GET
-  @Path("dummy")
+  @Path("dummy/{size}")
   @Produces(MediaType.APPLICATION_OCTET_STREAM)
-  public String getDummyArtifact() throws Exception {
+  public Response getDummyArtifact(@PathParam("size") int size) throws Exception {
     Random rand = new Random();
     rand.setSeed(System.currentTimeMillis());
     try {
-      // 100Kb
-      byte[] bytes = new byte[100000];
+      byte[] bytes = new byte[size*1024];
       rand.nextBytes(bytes);
-      return new String(bytes);
+      return Response.ok(bytes).build();
     } catch (Exception e) {
       e.printStackTrace();
-      return e.getMessage();
+      return Response.status(Response.Status.SERVICE_UNAVAILABLE).build();
     }
   }
 


### PR DESCRIPTION
Provides an endpoint to fetch up to 1MB of dummy data. This is used by local clients to determine if the network speed is fast enough